### PR TITLE
The count parameter in the method `choice` must be replaced if found.

### DIFF
--- a/js/lang.js
+++ b/js/lang.js
@@ -100,7 +100,10 @@
      */
     Lang.prototype.choice = function(key, count, replacements) {
         // Set default values for parameters replace and locale
-        replacements = typeof replacements !== 'undefined' ? replacements : [];
+        replacements = typeof replacements !== 'undefined' ? replacements : {};
+
+        // The count must be replaced if found in the message
+        replacements['count'] = count;
 
         // Message to get the plural or singular
         var message = this.get(key, replacements);

--- a/tests/lang/en/messages.php
+++ b/tests/lang/en/messages.php
@@ -42,5 +42,6 @@ return array(
                  'son' => 'Jimmy',
             ),
     ),
-    'plural' => 'one apple|a million apples'
+    'plural' => 'one apple|a million apples',
+    'plural' => ':count apple|:count apples'
 );

--- a/tests/spec/data/messages.json
+++ b/tests/spec/data/messages.json
@@ -105,7 +105,8 @@
                 "son": "Jimmy"
             }
         },
-        "plural": "one apple|a million apples"
+        "plural": "one apple|a million apples",
+        "pluralCount": ":count apple|:count apples"
     },
     "en.pagination": {
         "previous": "&laquo; Previous",

--- a/tests/spec/lang_choice_spec.js
+++ b/tests/spec/lang_choice_spec.js
@@ -33,4 +33,9 @@ describe('The Lang.choice() method', function() {
         })).toBe('The foo must be accepted.');
     });
 
+    it('should replace :count with the count param', function() {
+        expect(Lang.choice('messages.pluralCount', 1)).toBe('1 apple');
+        expect(Lang.choice('messages.pluralCount', 10)).toBe('10 apples');
+    });
+
 });


### PR DESCRIPTION
The count parameter in the method `choice` must be replaced with the wildcard `:count` if found in the message.

Test updated.