### PR TITLE
Put `'use strict'` direction inside of the methods

### DIFF
--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -7,9 +7,8 @@
  *  @author  rmariuzzo
  */
 
-'use strict';
-
 (function(root, factory) {
+    'use strict';
 
     if (typeof define === 'function' && define.amd) {
         // AMD support.
@@ -23,6 +22,7 @@
     }
 
 }(this, function() {
+    'use strict';
 
     // Default options //
 


### PR DESCRIPTION
This is necessary to make the script uglify-able along with other scripts.

Thanks.