### PR TITLE
Fix pluralization logic

### DIFF
--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -144,10 +144,10 @@
         }
 
         // Standard rules
-        if (count > 1) {
-            return messageParts[1];
-        } else {
+        if (count == 1) {
             return messageParts[0];
+        } else {
+            return messageParts[1];
         }
     };
 


### PR DESCRIPTION
The singular form should only be used if the count is 1: 
* I have 2 dollars
* I have 1 dollar
* I have 0 dollars
* I have -1 dollars

This may vary in other languages, but the existing logic is broken for English at least.  Perhaps language-specific logic is needed?