### PR TITLE
Add exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ php artisan lang:js public/assets/dist/lang.dist.js
 php artisan lang:js -c
 ```
 
+**Exclude lang files**
+
+```shell
+php artisan lang:js -e auth -e passwords
+```
+
 **Use [gulp](http://gulpjs.com/) to publish (optional):**
 
 install `gulp-shell` from https://github.com/sun-zheng-an/gulp-shell with `npm install --save-dev gulp-shell` 

--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -44,7 +44,10 @@ class LangJsCommand extends Command
     public function fire()
     {
         $target = $this->argument('target');
-        $options = ['compress' => $this->option('compress')];
+        $options = [
+            'compress' => $this->option('compress'),
+            'exclude' => $this->option('exclude'),
+        ];
 
         if ($this->generator->generate($target, $options))
         {
@@ -75,6 +78,7 @@ class LangJsCommand extends Command
     {
         return [
             ['compress', 'c', InputOption::VALUE_NONE, 'Compress the JavaScript file.', null],
+            ['exclude', 'e', InputArgument::OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Exclude lang files.', null],
         ];
     }
 

--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -40,7 +40,7 @@ class LangJsGenerator
      */
     public function generate($target, $options)
     {
-        $messages = $this->getMessages();
+        $messages = $this->getMessages($options);
         $this->prepareTarget($target);
 
         $template = $this->file->get(__DIR__ . '/Templates/langjs_with_messages.js');
@@ -60,9 +60,11 @@ class LangJsGenerator
     /**
      * Return all language messages.
      *
+     * @param array  $options Array of options.
+     *
      * @return array
      */
-    protected function getMessages()
+    protected function getMessages($options)
     {
         $messages = array();
         $path = $this->sourcePath;
@@ -77,6 +79,8 @@ class LangJsGenerator
             $pathName = $file->getRelativePathName();
 
             if ( $this->file->extension($pathName) !== 'php' ) continue;
+
+            if ( in_array($this->file->name($pathName), $options['exclude']) ) continue;
 
             $key = substr($pathName, 0, -4);
             $key = str_replace('\\', '.', $key);


### PR DESCRIPTION
Hello, I added an extra option to **exclude** certain language files, I think it might be useful in cases when some keys are not used on client side and create one lightest js file:

```php
php artisan lang:js -e auth -e passwords
```

I hope that option may interest you.