### PR TITLE
Add an ability to configurate list of files to convert to be used by javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ In your Laravel app go to `app/config/app.php` and add the following service pro
 ```
 That's it!
 
+## Configuration
+
+Run `php artisan vendor:publish --provider="Mariuzzo\LaravelJsLocalization\LaravelJsLocalizationServiceProvider"` first. This command copies the package's default configuration to `config/localization-js.php`.
+
+You may edit this file to define the messages you need in your Javascript code. Just edit the `messages` array in the config file. *Empty messages array will include all the language files in build.*
+
+To make only `pagination.php` & `validation.php` files to be included in build process:
+
+```php
+<?php
+
+return [
+
+    'messages' => [
+        'pagination',
+        'validation',
+    ],
+    
+];
+```
+
 ## Usage
 
 This project comes with a command that generate the JavaScript version of all your messages found at: `app/lang` or `resources/lang` directory. The resulting JavaScript file will have the whole bunch of messages and a thin library similar to Laravel's `Lang` class.

--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -21,6 +21,13 @@ class LangJsGenerator
     protected $sourcePath;
 
     /**
+     * List of messages should be included in build.
+     *
+     * @var array
+     */
+    protected $messagesIncluded = [];
+
+    /**
      * Construct a new LangJsGenerator instance.
      *
      * @param Illuminate\Filesystem\File $file       The file service instance.
@@ -30,6 +37,7 @@ class LangJsGenerator
     {
         $this->file = $file;
         $this->sourcePath = $sourcePath;
+        $this->collectMessagesIncluded();
     }
 
     /**
@@ -78,6 +86,10 @@ class LangJsGenerator
 
             if ( $this->file->extension($pathName) !== 'php' ) continue;
 
+            if ($this->isMessagesExcluded($file->getFileName())) {
+                continue;
+            }
+
             $key = substr($pathName, 0, -4);
             $key = str_replace('\\', '.', $key);
             $key = str_replace('/', '.', $key);
@@ -101,5 +113,33 @@ class LangJsGenerator
         {
             $this->file->makeDirectory($dirname, null, true);
         }
+    }
+
+    /**
+     * If messages should be excluded from build.
+     *
+     * @param $filename
+     * @return bool
+     */
+    protected function isMessagesExcluded($filename)
+    {
+        if (empty($this->messagesIncluded)) {
+            return false;
+        }
+
+        $filename = substr($filename, 0, -4);
+        if (in_array($filename, $this->messagesIncluded)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Prepare list of messages should be included in build.
+     */
+    protected function collectMessagesIncluded()
+    {
+        $this->messagesIncluded = config('localization-js.messages');
     }
 }

--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -17,6 +17,23 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
     protected $defer = false;
 
     /**
+     * Bootstrap the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // Publish config files
+        $this->publishes([
+            __DIR__ . '/../../config/config.php' => config_path('localization-js.php'),
+        ]);
+
+        $this->mergeConfigFrom(
+            __DIR__ . '/../../config/config.php', 'localization-js'
+        );
+    }
+
+    /**
      * Register the service provider.
      *
      * @return void


### PR DESCRIPTION
I've added configuration file for your package.

Right now there could be defined list of language files which should be included in javascript output.

Checks are done via separate method for easier extending functionality in future:
- [define excludes via console command](https://github.com/rmariuzzo/Laravel-JS-Localization/pull/41)
- add ability to include only exact messages in language files, not the whole files:

```php
'messages' => [
    'passwords.reset',
    'pagination.next',
    'pagination.previous',
],
```

2 more cases covered in unit tests, code cleaned up and formatted in PSR-2 (because it's standard since [Laravel 5.1](https://laravel.com/docs/master/releases#laravel-5.1)).