### PR TITLE
Added nested directory support to include from config

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -86,7 +86,7 @@ class LangJsGenerator
 
             if ( $this->file->extension($pathName) !== 'php' ) continue;
 
-            if ($this->isMessagesExcluded($file->getFileName())) {
+            if ($this->isMessagesExcluded($pathName)) {
                 continue;
             }
 
@@ -118,17 +118,21 @@ class LangJsGenerator
     /**
      * If messages should be excluded from build.
      *
-     * @param $filename
+     * @param string $filePath
      * @return bool
      */
-    protected function isMessagesExcluded($filename)
+    protected function isMessagesExcluded($filePath)
     {
         if (empty($this->messagesIncluded)) {
             return false;
         }
 
-        $filename = substr($filename, 0, -4);
-        if (in_array($filename, $this->messagesIncluded)) {
+        $localeDirSeparatorPosition = strpos($filePath, '/');
+        $filePath = substr($filePath, $localeDirSeparatorPosition);
+        $filePath = ltrim($filePath, '/');
+        $filePath = substr($filePath, 0, -4);
+
+        if (in_array($filePath, $this->messagesIncluded)) {
             return false;
         }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+     * Set the names of files you want to add to generated javascript.
+     * Otherwise all the files will be included.
+     *
+     * 'messages' => [
+     *     'validation',
+     *     'forum/thread',
+     * ],
+     */
+
+    'messages' => [
+
+    ],
+
+];

--- a/tests/LangJsCommandTest.php
+++ b/tests/LangJsCommandTest.php
@@ -138,6 +138,31 @@ class LangJsCommandTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testShouldIncludeNestedDirectoryFile()
+    {
+        $this->app['config']->set('localization-js.messages', [
+            'forum/thread',
+        ]);
+
+        $generator = new LangJsGenerator(new File(), __DIR__ . '/fixtures/lang');
+
+        $command = new LangJsCommand($generator);
+        $command->setLaravel($this->app);
+
+        $code = $this->runCommand($command, ['target' => $this->getOutputFilePath()]);
+
+        $this->assertRunsWithSuccess($code);
+
+        $this->assertFileExists($this->getOutputFilePath());
+
+        $contents = file_get_contents($this->getOutputFilePath());
+
+        $this->assertContains('en.forum.thread', $contents);
+    }
+
+    /**
      * Run the command.
      * @param \Illuminate\Console\Command $command
      * @param array $input

--- a/tests/fixtures/lang/en/forum/thread.php
+++ b/tests/fixtures/lang/en/forum/thread.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'viewAllThreads' => 'View all threads',
+
+];


### PR DESCRIPTION
Gives an ability to include nested directory language files:

```php
'messages' => [
    'validation',
    'forum/thread',
],
```

Will add `validation.php` and `forum/thread.php` files to generated javascript.

Adds missing `config.php` file from PR #47 