### PR TITLE
Add ability to specify path in config

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -71,8 +71,20 @@ class LangJsCommand extends Command
     protected function getArguments()
     {
         return [
-            ['target', InputArgument::OPTIONAL, 'Target path.', $this->getPublicPath().'/messages.js'],
+            ['target', InputArgument::OPTIONAL, 'Target path.', $this->getDefaultPath()],
         ];
+    }
+
+    /**
+     * Return the path to use when no path is specified.
+     *
+     * @return string
+     */
+    protected function getDefaultPath()
+    {
+        $default = $this->getPublicPath() . DIRECTORY_SEPARATOR . 'messages.js';
+
+        return config('localization-js.path', $default);
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,7 +2,7 @@
 
 return [
 
-    /*
+    /**
      * Set the names of files you want to add to generated javascript.
      * Otherwise all the files will be included.
      *
@@ -11,9 +11,12 @@ return [
      *     'forum/thread',
      * ],
      */
-
     'messages' => [
 
     ],
 
+    /**
+     * The default path to use for the generated javascript.
+     */
+    'path' => public_path() . DIRECTORY_SEPARATOR . 'messages.js',
 ];


### PR DESCRIPTION
This allows you to specify a path in the config so that you don't have to explicitly specify it every time you use `artisan lang:js`.