### PR TITLE
Add ability to specify path in config

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -83,9 +83,7 @@ class LangJsCommand extends Command
      */
     protected function getDefaultPath()
     {
-        $default = $this->getPublicPath() . DIRECTORY_SEPARATOR . 'messages.js';
-
-        return Config::get('localization-js.path', $default);
+        return Config::get('localization-js.path', public_path('messages.js'));
     }
 
     /**
@@ -98,15 +96,5 @@ class LangJsCommand extends Command
         return [
             ['compress', 'c', InputOption::VALUE_NONE, 'Compress the JavaScript file.', null],
         ];
-    }
-
-    /**
-     * Return the public path of the Laravel application.
-     *
-     * @return string
-     */
-    public function getPublicPath()
-    {
-        return public_path();
     }
 }

--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -71,8 +71,20 @@ class LangJsCommand extends Command
     protected function getArguments()
     {
         return [
-            ['target', InputArgument::OPTIONAL, 'Target path.', $this->getPublicPath().'/messages.js'],
+            ['target', InputArgument::OPTIONAL, 'Target path.', $this->getDefaultPath()],
         ];
+    }
+
+    /**
+     * Return the path to use when no path is specified.
+     *
+     * @return string
+     */
+    protected function getDefaultPath()
+    {
+        $default = $this->getPublicPath() . DIRECTORY_SEPARATOR . 'messages.js';
+
+        return config('localization-js.path', $default);
     }
 
     /**

--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Mariuzzo\LaravelJsLocalization\Commands;
 
+use Config;
 use Illuminate\Console\Command;
 use Mariuzzo\LaravelJsLocalization\Generators\LangJsGenerator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -84,7 +85,7 @@ class LangJsCommand extends Command
     {
         $default = $this->getPublicPath() . DIRECTORY_SEPARATOR . 'messages.js';
 
-        return config('localization-js.path', $default);
+        return Config::get('localization-js.path', $default);
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,7 +2,7 @@
 
 return [
 
-    /**
+    /*
      * Set the names of files you want to add to generated javascript.
      * Otherwise all the files will be included.
      *
@@ -15,8 +15,8 @@ return [
 
     ],
 
-    /**
+    /*
      * The default path to use for the generated javascript.
      */
-    'path' => public_path() . DIRECTORY_SEPARATOR . 'messages.js',
+    'path' => public_path('messages.js'),
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,7 +2,7 @@
 
 return [
 
-    /*
+    /**
      * Set the names of files you want to add to generated javascript.
      * Otherwise all the files will be included.
      *
@@ -11,9 +11,12 @@ return [
      *     'forum/thread',
      * ],
      */
-
     'messages' => [
 
     ],
 
+    /**
+     * The default path to use for the generated javascript.
+     */
+    'path' => public_path() . DIRECTORY_SEPARATOR . 'messages.js',
 ];


### PR DESCRIPTION
See #59 

This allows you to specify a path in the config so that you don't have to explicitly specify it every time you use `artisan lang:js`.

If this can be released as a path it would be ideal, as we're not changing the API and preserving backward compatibility.