### PR TITLE
Specifying a custom  source folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ php artisan lang:js public/assets/dist/lang.dist.js
 php artisan lang:js -c
 ```
 
+### Specifying a custom source folder
+
+```shell
+php artisan lang:js public/assets/dist/lang.dist.js -s themes/default/lang
+```
+
 ## Configuration
 
 First, publish the default package's configuration file running:

--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -53,7 +53,10 @@ class LangJsCommand extends Command
     public function fire()
     {
         $target = $this->argument('target');
-        $options = ['compress' => $this->option('compress')];
+        $options = [
+            'compress' => $this->option('compress'),
+            'source' => $this->option('source'),
+        ];
 
         if ($this->generator->generate($target, $options)) {
             $this->info("Created: {$target}");
@@ -95,6 +98,7 @@ class LangJsCommand extends Command
     {
         return [
             ['compress', 'c', InputOption::VALUE_NONE, 'Compress the JavaScript file.', null],
+            ['source', 's', InputOption::VALUE_REQUIRED, 'Specifying a custom source folder', null],
         ];
     }
 }

--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -56,6 +56,10 @@ class LangJsGenerator
      */
     public function generate($target, $options)
     {
+        if ($options['source']) {
+            $this->sourcePath = $options['source'];
+        }
+
         $messages = $this->getMessages();
         $this->prepareTarget($target);
 

--- a/tests/fixtures/theme/lang/en/page.php
+++ b/tests/fixtures/theme/lang/en/page.php
@@ -1,0 +1,5 @@
+<?php
+
+return array(
+    'header' => 'My Site'
+);

--- a/tests/specs/LangJsCommandTest.php
+++ b/tests/specs/LangJsCommandTest.php
@@ -226,13 +226,9 @@ class LangJsCommandTest extends TestCase
         $command = new LangJsCommand($generator);
         $command->setLaravel($this->app);
 
-        $outputDir = $this->testPath.'/output/';
-
-        FileFacade::copyDirectory($this->langPath, $outputDir);
-
         $code = $this->runCommand($command,[
                 'target' => $this->outputFilePath,
-                '-s' => $outputDir,
+                '-s' => "$this->testPath/fixtures/theme/lang",
             ]
         );
         $this->assertRunsWithSuccess($code);
@@ -241,6 +237,9 @@ class LangJsCommandTest extends TestCase
         $template = "$this->rootPath/src/Mariuzzo/LaravelJsLocalization/Generators/Templates/langjs_with_messages.js";
         $this->assertFileExists($template);
         $this->assertFileNotEquals($template, $this->outputFilePath);
+
+        $contents = file_get_contents($this->outputFilePath);
+        $this->assertContains('en.page', $contents);
 
         $this->cleanupOutputDirectory();
     }
@@ -312,11 +311,6 @@ class LangJsCommandTest extends TestCase
         $files = FileFacade::files("{$this->testPath}/output");
         foreach ($files as $file) {
             FileFacade::delete($file);
-        }
-
-        $directories = FileFacade::directories("{$this->testPath}/output");
-        foreach ($directories as $directory) {
-            FileFacade::deleteDirectory($directory);
         }
     }
 }

--- a/tests/specs/LangJsCommandTest.php
+++ b/tests/specs/LangJsCommandTest.php
@@ -218,6 +218,51 @@ class LangJsCommandTest extends TestCase
     }
 
     /**
+     */
+    public function testChangeDefaultLangSourceFolder()
+    {
+        $generator = new LangJsGenerator(new File(), $this->langPath);
+
+        $command = new LangJsCommand($generator);
+        $command->setLaravel($this->app);
+
+        $outputDir = $this->testPath.'/output/';
+
+        FileFacade::copyDirectory($this->langPath, $outputDir);
+
+        $code = $this->runCommand($command,[
+                'target' => $this->outputFilePath,
+                '-s' => $outputDir,
+            ]
+        );
+        $this->assertRunsWithSuccess($code);
+        $this->assertFileExists($this->outputFilePath);
+
+        $template = "$this->rootPath/src/Mariuzzo/LaravelJsLocalization/Generators/Templates/langjs_with_messages.js";
+        $this->assertFileExists($template);
+        $this->assertFileNotEquals($template, $this->outputFilePath);
+
+        $this->cleanupOutputDirectory();
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testChangeDefaultLangSourceFolderForOneThatDosentExist()
+    {
+        $generator = new LangJsGenerator(new File(), $this->langPath);
+
+        $command = new LangJsCommand($generator);
+        $command->setLaravel($this->app);
+
+        $code = $this->runCommand($command,[
+                'target' => $this->outputFilePath,
+                '-s' => $this->langPath.'/non-exist',
+            ]
+        );
+    }
+
+    /**
      * Run the command.
      *
      * @param \Illuminate\Console\Command $command
@@ -267,6 +312,11 @@ class LangJsCommandTest extends TestCase
         $files = FileFacade::files("{$this->testPath}/output");
         foreach ($files as $file) {
             FileFacade::delete($file);
+        }
+
+        $directories = FileFacade::directories("{$this->testPath}/output");
+        foreach ($directories as $directory) {
+            FileFacade::deleteDirectory($directory);
         }
     }
 }


### PR DESCRIPTION
Hello,

I added an option to specify a folder different than the default location in Laravel.

In one project, i needed to generate different js files, from different sources.

I've added an option to solve that problem this way:

`php artisan lang:js public/assets/dist/lang.dist.js -s themes/default/lang`

I hope this may be interesting for you. Thanks.