### PR TITLE
Add handling of vendor translations

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -102,6 +102,10 @@ class LangJsGenerator
             $key = substr($pathName, 0, -4);
             $key = str_replace('\\', '.', $key);
             $key = str_replace('/', '.', $key);
+            
+            if (starts_with($key, 'vendor')) {
+                $key = $this->getVendorKey($key);
+            }
 
             $messages[$key] = include $path . DIRECTORY_SEPARATOR . $pathName;
         }
@@ -148,5 +152,13 @@ class LangJsGenerator
         }
 
         return true;
+    }
+    
+    private function getVendorKey($key)
+    {
+        $keyParts = explode('.', $key, 4);
+        unset($keyParts[0]);
+
+        return $keyParts[2] .'.'. $keyParts[1] . '::' . $keyParts[3];
     }
 }

--- a/tests/fixtures/lang/vendor/nonameinc/en/messages.php
+++ b/tests/fixtures/lang/vendor/nonameinc/en/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+
+    'important_data' => 'works perfect',
+    
+);

--- a/tests/fixtures/lang/vendor/nonameinc/es/messages.php
+++ b/tests/fixtures/lang/vendor/nonameinc/es/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+
+    'important_data' => 'funciona perfectamente',
+
+);

--- a/tests/fixtures/lang/vendor/nonameinc/ht/messages.php
+++ b/tests/fixtures/lang/vendor/nonameinc/ht/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+
+    'home' => 'travay pafètman',
+
+);

--- a/tests/specs/LangJsCommandTest.php
+++ b/tests/specs/LangJsCommandTest.php
@@ -114,6 +114,14 @@ class LangJsCommandTest extends TestCase
 
         $contents = file_get_contents($this->outputFilePath);
         $this->assertContains('gm8ft2hrrlq1u6m54we9udi', $contents);
+        
+        $this->assertNotContains('vendor.nonameinc.en.messages', $contents);
+        $this->assertNotContains('vendor.nonameinc.es.messages', $contents);
+        $this->assertNotContains('vendor.nonameinc.ht.messages', $contents);
+
+        $this->assertContains('en.nonameinc::messages', $contents);
+        $this->assertContains('es.nonameinc::messages', $contents);
+        $this->assertContains('ht.nonameinc::messages', $contents);
     }
 
     /**


### PR DESCRIPTION
Now If I publish lang files from packages with:

```sh
php artisan lang:js
```

It converts it to `vendor.${VENDOR_NAME}.${LOCALE}.${FILE}` and `Lang.get('${VENDOR_NAME}::${FILE}.${KEY}')` is not working but in Laravel It works.

This PR changes key `vendor.${VENDOR_NAME}.${LOCALE}.${FILE}` to  `${LOCALE}.${VENDOR_NAME}::${FILE}` so it give ability to use  `Lang.get('${VENDOR_NAME}::${FILE}.${KEY}')` as in Laravel.