### PR TITLE
Laravel 5.5 compatibility

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -50,7 +50,7 @@ class LangJsCommand extends Command
     /**
      * Fire the command.
      */
-    public function fire()
+    public function handle()
     {
         $target = $this->argument('target');
         $options = [


### PR DESCRIPTION
  Laravel 5.5 compatibility for `fire` -> `handle` method naming in console commands.