### PR TITLE
Release 1.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 php:

--- a/composer.json
+++ b/composer.json
@@ -70,5 +70,12 @@
             "./tests/5.3/run",
             "./tests/5.4/run"
         ]
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Mariuzzo\\LaravelJsLocalization\\LaravelJsLocalizationServiceProvider"
+            ]
+        }
     }
 }

--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -48,9 +48,17 @@ class LangJsCommand extends Command
     }
 
     /**
-     * Fire the command.
+     * Fire the command. (Compatibility for < 5.0)
      */
     public function fire()
+    {
+        $this->handle();
+    }
+
+    /**
+     * Handle the command.
+     */
+    public function handle()
     {
         $target = $this->argument('target');
         $options = [


### PR DESCRIPTION
This support release includes the following highlights:

 - Command compatibility with Laravel 5.4+ (436c4e3 by @dbpolito).
 - Trusty distribution added for Travis CS (bc8e316 by @rmariuzzo).
 - Support for [Laravel 5.5 LTS package auto-discovery](https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518) (023e8f4 by @dppolito).

Sorry for the mess in the commits, my `git rebase`-fu are not that strong.