### PR TITLE
Add support for "path must contain name"

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -34,16 +34,24 @@ class LangJsGenerator
     protected $messagesIncluded = [];
 
     /**
+     * A string within the path that must occur, in order to add the file.
+     *
+     * @var string
+     */
+    protected $pathContains;
+
+    /**
      * Construct a new LangJsGenerator instance.
      *
      * @param File   $file       The file service instance.
      * @param string $sourcePath The source path of the language files.
      */
-    public function __construct(File $file, $sourcePath, $messagesIncluded = [])
+    public function __construct(File $file, $sourcePath, $messagesIncluded = [], $pathContains = [])
     {
         $this->file = $file;
         $this->sourcePath = $sourcePath;
         $this->messagesIncluded = $messagesIncluded;
+        $this->pathContains = $pathContains;
     }
 
     /**
@@ -125,6 +133,10 @@ class LangJsGenerator
                 continue;
             }
 
+            if (!$this->isPathIncluded($pathName)) {
+                continue;
+            }
+
             $key = substr($pathName, 0, -4);
             $key = str_replace('\\', '.', $key);
             $key = str_replace('/', '.', $key);
@@ -181,7 +193,31 @@ class LangJsGenerator
 
         return true;
     }
-    
+
+    /**
+     * If path should be included in the build.
+     *
+     * @param string $filePath
+     *
+     * @return bool
+     */
+    protected function isPathIncluded($filePath)
+    {
+        if (empty($this->pathContains)) {
+            return true;
+        }
+
+        $filePath = str_replace(DIRECTORY_SEPARATOR, '/', $filePath);
+        $filePath = ltrim($filePath, '/');
+        $filePath = substr($filePath, 0, -4);
+
+        foreach($this->pathContains AS $word)
+            if(stristr($filePath, $word))
+                return true;
+
+        return false;
+    }
+
     private function getVendorKey($key)
     {
         $keyParts = explode('.', $key, 4);

--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -76,7 +76,8 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
                 $langs = $app['path.base'].'/resources/lang';
             }
             $messages = $app['config']->get('localization-js.messages');
-            $generator = new Generators\LangJsGenerator($files, $langs, $messages);
+            $pathContains = $app['config']->get('localization-js.pathContains');
+            $generator = new Generators\LangJsGenerator($files, $langs, $messages, $pathContains);
 
             return new Commands\LangJsCommand($generator);
         });

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -17,7 +17,7 @@ return [
 
     /*
      * Set the name(s) a file must contain, for it to be included on the generated javascript.
-     * E.g. if you place all language files for JS in a seperate folder: lang/en/js/example.php, you can use:
+     * E.g. if you place all language files for JS in a separate folder: lang/en/js/example.php, you can use:
      *
      * 'pathContains' => [
             'js'

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -16,6 +16,19 @@ return [
     ],
 
     /*
+     * Set the name(s) a file must contain, for it to be included on the generated javascript.
+     * E.g. if you place all language files for JS in a seperate folder: lang/en/js/example.php, you can use:
+     *
+     * 'pathContains' => [
+            'js'
+     * ],
+     * Note: this method will check the occurrance of the name, in the full file path (including the file name, but not extension)
+     */
+    'pathContains' => [
+
+    ],
+
+    /*
      * The default path to use for the generated javascript.
      */
     'path' => public_path('messages.js'),


### PR DESCRIPTION
With this, you can place all language files used by JS, in a specific directory, or give the files a specific name. This is a more dynamic method than "$messagesIncluded" (of which I think the name makes no sense)