### PR TITLE
Update minimum PHP requirements to support Laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "source": "https://github.com/rmariuzzo/laravel-js-localization"
     },
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.4.0",
         "illuminate/config": ">=4.2",
         "illuminate/console": ">=4.2",
         "illuminate/filesystem": ">=4.2",


### PR DESCRIPTION
Refer with #90, I tested from a project created from Laravel 4.2 and verify minimum version from both Laravel 4.2.11 and latest Laravel 5.5.0.

Basically, Composer would resolve final minimal PHP version from checking all dependencies. If other packages needs higher version, it would solved to that specific version anyway then it wouldn't conflict for changing minimal version within this package.