### PR TITLE
Added optional --no-sort option

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -66,6 +66,7 @@ class LangJsCommand extends Command
             'json' => $this->option('json'),
             'no-lib' => $this->option('no-lib'),
             'source' => $this->option('source'),
+            'no-sort' => $this->option('no-sort'),
         ];
 
         if ($this->generator->generate($target, $options)) {
@@ -111,6 +112,7 @@ class LangJsCommand extends Command
             ['no-lib', 'nl', InputOption::VALUE_NONE, 'Do not include the lang.js library.', null],
             ['json', 'j', InputOption::VALUE_NONE, 'Only output the messages json.', null],
             ['source', 's', InputOption::VALUE_REQUIRED, 'Specifying a custom source folder', null],
+            ['no-sort', 'ns', InputOption::VALUE_NONE, 'Do not sort the messages', null],
         ];
     }
 }

--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -36,7 +36,7 @@ class LangJsGenerator
     /**
      * Name of the domain in which all string-translation should be stored under.
      * More about string-translation: https://laravel.com/docs/master/localization#retrieving-translation-strings
-     * 
+     *
      * @var string
      */
     protected $stringsDomain = 'strings';
@@ -68,7 +68,7 @@ class LangJsGenerator
             $this->sourcePath = $options['source'];
         }
 
-        $messages = $this->getMessages();
+        $messages = $this->getMessages($options['no-sort']);
         $this->prepareTarget($target);
 
         if ($options['no-lib']) {
@@ -109,11 +109,12 @@ class LangJsGenerator
     /**
      * Return all language messages.
      *
+     * @param bool $noSort Whether sorting of the messages should be skipped.
      * @return array
      *
      * @throws \Exception
      */
-    protected function getMessages()
+    protected function getMessages($noSort)
     {
         $messages = [];
         $path = $this->sourcePath;
@@ -151,7 +152,10 @@ class LangJsGenerator
             }
         }
 
-        $this->sortMessages($messages);
+        if (!$noSort)
+        {
+            $this->sortMessages($messages);
+        }
 
         return $messages;
     }
@@ -196,7 +200,7 @@ class LangJsGenerator
 
         return true;
     }
-    
+
     private function getVendorKey($key)
     {
         $keyParts = explode('.', $key, 4);

--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -48,7 +48,7 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
         if ($laravelMajorVersion === 4) {
             $config = $this->app['config']->get($configKey, []);
             $this->app['config']->set($configKey, array_merge(require $configPath, $config));
-        } elseif ($laravelMajorVersion === 5) {
+        } elseif ($laravelMajorVersion > 5) {
             $this->publishes([
                 $configPath => config_path("$configKey.php"),
             ]);
@@ -67,12 +67,12 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
         $this->app->singleton('localization.js', function ($app) {
             $app = $this->app;
             $laravelMajorVersion = (int) $app::VERSION;
-            
+
             $files = $app['files'];
-            
+
             if ($laravelMajorVersion === 4) {
                 $langs = $app['path.base'].'/app/lang';
-            } elseif ($laravelMajorVersion === 5) {
+            } elseif ($laravelMajorVersion > 5) {
                 $langs = $app['path.base'].'/resources/lang';
             }
             $messages = $app['config']->get('localization-js.messages');

--- a/tests/specs/LangJsCommandTest.php
+++ b/tests/specs/LangJsCommandTest.php
@@ -127,7 +127,7 @@ class LangJsCommandTest extends TestCase
 
         $contents = file_get_contents($this->outputFilePath);
         $this->assertContains('gm8ft2hrrlq1u6m54we9udi', $contents);
-        
+
         $this->assertNotContains('vendor.nonameinc.en.messages', $contents);
         $this->assertNotContains('vendor.nonameinc.es.messages', $contents);
         $this->assertNotContains('vendor.nonameinc.ht.messages', $contents);
@@ -321,6 +321,48 @@ class LangJsCommandTest extends TestCase
                 '-s' => $this->langPath.'/non-exist',
             ]
         );
+    }
+
+    /**
+     * Test that messages are sorted alphabetically by default.
+     */
+    public function testDoesSortMessages()
+    {
+        $generator = new LangJsGenerator(new File(), $this->langPath, ['pagination']);
+
+        $command = new LangJsCommand($generator);
+        $command->setLaravel($this->app);
+
+        $code = $this->runCommand($command, ['target' => $this->outputFilePath]);
+        $this->assertRunsWithSuccess($code);
+        $this->assertFileExists($this->outputFilePath);
+
+        $contents = file_get_contents($this->outputFilePath);
+        $this->assertContains('en.pagination', $contents);
+        $this->assertContains('{"next":"Next &raquo;","previous":"&laquo; Previous"}', $contents);
+
+        $this->cleanupOutputDirectory();
+    }
+
+    /**
+     * Tests that the --no-sort option does not sort messages.
+     */
+    public function testDoesNotSortMessages()
+    {
+        $generator = new LangJsGenerator(new File(), $this->langPath, ['pagination']);
+
+        $command = new LangJsCommand($generator);
+        $command->setLaravel($this->app);
+
+        $code = $this->runCommand($command, ['target' => $this->outputFilePath, '--no-sort' => true]);
+        $this->assertRunsWithSuccess($code);
+        $this->assertFileExists($this->outputFilePath);
+
+        $contents = file_get_contents($this->outputFilePath);
+        $this->assertContains('en.pagination', $contents);
+        $this->assertContains('{"previous":"&laquo; Previous","next":"Next &raquo;"}', $contents);
+
+        $this->cleanupOutputDirectory();
     }
 
     /**


### PR DESCRIPTION
Use case is I have arrays in the language files which will be converted into options for a select input such as timezones:

```
        'ES' => [
            'Europe/Madrid'   => 'Europe/Madrid',
            'Africa/Ceuta'    => 'Africa/Ceuta',
            'Atlantic/Canary' => 'Atlantic/Canary',
        ],
```

I want them to be in the order that I specify them in the file rather than sorted alphabetically. This applies to other arrays that I have in my language files.