### PR TITLE
updated required version of tedivm/jshrink to offer php7.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "illuminate/config": ">=4.2",
         "illuminate/console": ">=4.2",
         "illuminate/filesystem": ">=4.2",
-        "tedivm/jshrink": "1.0.*"
+        "tedivm/jshrink": "^1.3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*"


### PR DESCRIPTION
Updated composer.json to require ^1.3.1 of jshrink in order to fix php7.3 compatibility issues 