### PR TITLE
Added autodetecter feature

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -74,7 +74,6 @@ class LangJsCommand extends Command
         if ($options['autodetect']) {
             $this->info('Autodetect enabled... If this takes too long, edit the glob\'s in config/js-localization.php to be more specific');
             $usageSearchFiles = $this->generator->usageSearchFiles($this->getUsageSearchFiles());
-            $this->info(print_r($usageSearchFiles,true));
             $bar = $this->output->createProgressBar(count($usageSearchFiles));
             $bar->start();
             foreach ($usageSearchFiles as $file){
@@ -82,8 +81,7 @@ class LangJsCommand extends Command
                 $bar->advance();
             }
             $bar->finish();
-
-            $this->info(print_r($this->generator->keepMessages,true));
+            $this->info("\n");
         }
 
         if ($this->generator->generate($target, $options)) {
@@ -118,13 +116,17 @@ class LangJsCommand extends Command
     }
 
     /**
-     * Return the path to use when no path is specified.
+     * Return the glob's to search.
      *
-     * @return string
+     * @return array
      */
     protected function getUsageSearchFiles()
     {
-        return Config::get('localization-js.usageSearchFiles', []);
+        return Config::get('localization-js.usageSearchFiles', [
+            'public/**/*.js',
+            'resources/assets/**/*.js',
+            'resources/views/**/*',
+        ]);
     }
 
     /**

--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -67,7 +67,24 @@ class LangJsCommand extends Command
             'no-lib' => $this->option('no-lib'),
             'source' => $this->option('source'),
             'no-sort' => $this->option('no-sort'),
+            'autodetect' => $this->option('autodetect'),
         ];
+
+
+        if ($options['autodetect']) {
+            $this->info('Autodetect enabled... If this takes too long, edit the glob\'s in config/js-localization.php to be more specific');
+            $usageSearchFiles = $this->generator->usageSearchFiles($this->getUsageSearchFiles());
+            $this->info(print_r($usageSearchFiles,true));
+            $bar = $this->output->createProgressBar(count($usageSearchFiles));
+            $bar->start();
+            foreach ($usageSearchFiles as $file){
+                $this->generator->usageSearch($file);
+                $bar->advance();
+            }
+            $bar->finish();
+
+            $this->info(print_r($this->generator->keepMessages,true));
+        }
 
         if ($this->generator->generate($target, $options)) {
             $this->info("Created: {$target}");
@@ -101,6 +118,16 @@ class LangJsCommand extends Command
     }
 
     /**
+     * Return the path to use when no path is specified.
+     *
+     * @return string
+     */
+    protected function getUsageSearchFiles()
+    {
+        return Config::get('localization-js.usageSearchFiles', []);
+    }
+
+    /**
      * Return all command options.
      *
      * @return array
@@ -113,6 +140,7 @@ class LangJsCommand extends Command
             ['json', 'j', InputOption::VALUE_NONE, 'Only output the messages json.', null],
             ['source', 's', InputOption::VALUE_REQUIRED, 'Specifying a custom source folder', null],
             ['no-sort', 'ns', InputOption::VALUE_NONE, 'Do not sort the messages', null],
+            ['autodetect', 'a', InputOption::VALUE_NONE, 'Autodetect which messages to include', null],
         ];
     }
 }

--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -2,7 +2,6 @@
 
 namespace Mariuzzo\LaravelJsLocalization\Generators;
 
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use InvalidArgumentException;
 use Illuminate\Filesystem\Filesystem as File;
 use Illuminate\Support\Str;
@@ -42,7 +41,7 @@ class LangJsGenerator
      *
      * @var array
      */
-    protected $keepMessages = [];
+    public $keepMessages = [];
 
     /**
      * Name of the domain in which all string-translation should be stored under.
@@ -82,6 +81,7 @@ class LangJsGenerator
 
         $messages = $this->getMessages($options['no-sort']);
         if ($options['autodetect']) {
+            print_r($this->keepMessages);
             $this->filterKeepMessages($messages,$this->keepMessages);
         }
         $this->prepareTarget($target);
@@ -123,7 +123,7 @@ class LangJsGenerator
 
     /**
      * Returns array of filenames from input glob's.
-     * @param $globs Globs to parse
+     * @param array $globs Globs to parse
      * @return array
      */
     public function usageSearchFiles($globs)
@@ -137,7 +137,8 @@ class LangJsGenerator
 
     /**
      * Searches a file for Lang.get / Lang.has / Lang.choice etc. occurances.
-     * @param $file Absolute path of file to open
+     * Stores an occurence in $this->keepMessages;
+     * @param string $file Absolute path of file to open
      * @return void
      */
     public function usageSearch($file)
@@ -162,8 +163,8 @@ class LangJsGenerator
 
     /**
      * Recursively executes array_intersect_key($array1, $array2);
-     * @param $array1 Array of master keys
-     * @param $array2 Array to check keys against
+     * @param array $array1 Array of master keys
+     * @param array $array2 Array to check keys against
      * @see array_intersect_key()
      * @return array
      */
@@ -179,8 +180,8 @@ class LangJsGenerator
 
     /**
      * Filters language keys in $messages to only keep keys in $this->keepMessages;
-     * @param &$messages Array of master keys
-     * @param &$keep Array of keys to keep
+     * @param array &$messages Array of master keys
+     * @param array &$keep Array of keys to keep
      * @return void
      */
     protected function filterKeepMessages(&$messages, &$keep){

--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -81,7 +81,6 @@ class LangJsGenerator
 
         $messages = $this->getMessages($options['no-sort']);
         if ($options['autodetect']) {
-            print_r($this->keepMessages);
             $this->filterKeepMessages($messages,$this->keepMessages);
         }
         $this->prepareTarget($target);

--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -76,8 +76,7 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
                 $langs = $app['path.base'].'/resources/lang';
             }
             $messages = $app['config']->get('localization-js.messages');
-            $usageSearchFiles = $app['config']->get('localization-js.usageSearchFiles');
-            $generator = new Generators\LangJsGenerator($files, $langs, $messages, $usageSearchFiles);
+            $generator = new Generators\LangJsGenerator($files, $langs, $messages);
 
             return new Commands\LangJsCommand($generator);
         });

--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -76,7 +76,8 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
                 $langs = $app['path.base'].'/resources/lang';
             }
             $messages = $app['config']->get('localization-js.messages');
-            $generator = new Generators\LangJsGenerator($files, $langs, $messages);
+            $usageSearchFiles = $app['config']->get('localization-js.usageSearchFiles');
+            $generator = new Generators\LangJsGenerator($files, $langs, $messages, $usageSearchFiles);
 
             return new Commands\LangJsCommand($generator);
         });

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -26,7 +26,7 @@ return [
      * Use glob format. https://en.wikipedia.org/wiki/Glob_(programming)
      */
     'usageSearchFiles' => [
-        'public/**/.js',
+        'public/**/*.js',
         'resources/assets/**/*.js',
         'resources/views/**/*',
     ],

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -19,4 +19,19 @@ return [
      * The default path to use for the generated javascript.
      */
     'path' => public_path('messages.js'),
+
+    /*
+     * Specify the files you want the autodetector to search through.
+     * Use glob format.
+     *
+     * 'usageSearchFiles' => [
+     *     'validation',
+     *     'forum/thread',
+     * ],
+     */
+    'usageSearchFiles' => [
+        'public/**/.js',
+        'resources/assets/**/*.js',
+        'resources/views/**/*',
+    ],
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -22,12 +22,8 @@ return [
 
     /*
      * Specify the files you want the autodetector to search through.
-     * Use glob format.
-     *
-     * 'usageSearchFiles' => [
-     *     'validation',
-     *     'forum/thread',
-     * ],
+     * The autodetector looks for Lang.get / Lang.has / Lang.choice usages in your Javascript files.
+     * Use glob format. https://en.wikipedia.org/wiki/Glob_(programming)
      */
     'usageSearchFiles' => [
         'public/**/.js',


### PR DESCRIPTION
Adds option `-a` or `--autodetect` to the `php artisan lang:js` command.
The autodetector searches files given by glob's set in the js-localization.php config file for `Lang.get()` / `Lang.has()` / `Lang.choice()` etc. usages.