### PR TITLE
Support moved language resource path in Laravel 9+

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -72,8 +72,10 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
 
             if ($laravelMajorVersion === 4) {
                 $langs = $app['path.base'].'/app/lang';
-            } elseif ($laravelMajorVersion >= 5) {
+            } elseif ($laravelMajorVersion >= 5 && $laravelMajorVersion < 9) {
                 $langs = $app['path.base'].'/resources/lang';
+            } elseif ($laravelMajorVersion >= 9) {
+                $langs = app()->langPath();
             }
             $messages = $app['config']->get('localization-js.messages');
             $generator = new Generators\LangJsGenerator($files, $langs, $messages);


### PR DESCRIPTION
Laravel 9 [moves](https://laravel.com/docs/9.x/upgrade#the-lang-directory) the language directory, breaking the current implementation.

This change uses `app()->langPath()` in Laravel 9+ to dynamically get the language resource path, as recommended per documentation.