### PR TITLE
Updated lang path getting mechanism

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -69,11 +69,11 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
             $laravelMajorVersion = (int) $app::VERSION;
 
             $files = $app['files'];
-
+            
             if ($laravelMajorVersion === 4) {
                 $langs = $app['path.base'].'/app/lang';
-            } elseif ($laravelMajorVersion >= 5) {
-                $langs = $app['path.base'].'/resources/lang';
+            } else {
+                $langs = $app->langPath();
             }
             $messages = $app['config']->get('localization-js.messages');
             $generator = new Generators\LangJsGenerator($files, $langs, $messages);


### PR DESCRIPTION
Defining of localization folder has been updated: Laravel 9 has new lang folder path: '/lang', this causes an exception: 'resources/lang doesn't exists!' during the files creation.

In Laravel 5.0 (also available in newer version) App::langPath() method has been added, which helps to get lang folder absolute path, so there is no need to manually build path to lang folder anymore