### PR TITLE
Supports ever changing lang folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The configuration will be published to `config/localization-js.php`.
 
 You may edit this file to define the messages you need in your Javascript code. Just edit the `messages` array in the config file. **Empty messages array will include all the language files in build**.
 
+
 To make only `pagination.php` and `validation.php` files to be included in build process:
 
 ```php
@@ -92,6 +93,10 @@ return [
     ],
 ];
 ```
+
+### Specifying the path to your language folder
+
+Out of the box, this package points to `/app/lang` in Laravel 4 or the `resources/lang` in Laravel >= 5 but you can specify where yours exists by editing the `lang_path` key in the config file.
 
 ### Using [gulp](http://gulpjs.com/) (optional)
 

--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -70,11 +70,17 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
 
             $files = $app['files'];
 
-            if ($laravelMajorVersion === 4) {
-                $langs = $app['path.base'].'/app/lang';
-            } elseif ($laravelMajorVersion >= 5) {
-                $langs = $app['path.base'].'/resources/lang';
+            $languagePath = $this->app['config']->get('localization-js')['lang_path'];
+            if (empty($languagePath)) {
+                if ($laravelMajorVersion === 4) {
+                    $languagePath = 'app/lang';
+                    $langs = $app['path.base'].'/app/lang';
+                } elseif ($laravelMajorVersion >= 5) {
+                    $languagePath = 'resources/lang';
+                }
             }
+            $langs = $app['path.base'].$languagePath;
+
             $messages = $app['config']->get('localization-js.messages');
             $generator = new Generators\LangJsGenerator($files, $langs, $messages);
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -19,4 +19,9 @@ return [
      * The default path to use for the generated javascript.
      */
     'path' => public_path('messages.js'),
+
+    /*
+     * The path for your laravel lang folder
+     */
+    'lang_path' => '',
 ];


### PR DESCRIPTION
From laravel 4 to 8.x we've seen changes to where the `lang` folder lives and this breaks the functionality of this package.

This PR makes this path customisable, so the package does not need to be updated every time laravel makes an update to the location of this folder.