### PR TITLE
Make command lazy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "source": "https://github.com/rmariuzzo/laravel-js-localization"
     },
     "require": {
-        "php": "^5.4 || ^7.0 || ^8.0",
+        "php": "^5.5 || ^7.0 || ^8.0",
         "illuminate/config": "^4.2 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/console": "^4.2 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/filesystem": "^4.2 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",

--- a/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Commands/LangJsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Mariuzzo\LaravelJsLocalization\Commands;
 
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Console\Command;
 use Mariuzzo\LaravelJsLocalization\Generators\LangJsGenerator;
@@ -30,35 +31,17 @@ class LangJsCommand extends Command
     protected $description = 'Generate JS lang files.';
 
     /**
-     * The generator instance.
-     *
-     * @var LangJsGenerator
-     */
-    protected $generator;
-
-    /**
-     * Construct a new LangJsCommand.
-     *
-     * @param LangJsGenerator $generator The generator.
-     */
-    public function __construct(LangJsGenerator $generator)
-    {
-        $this->generator = $generator;
-        parent::__construct();
-    }
-
-    /**
      * Fire the command. (Compatibility for < 5.0)
      */
     public function fire()
     {
-        $this->handle();
+        $this->handle(App::make(LangJsGenerator::class));
     }
 
     /**
      * Handle the command.
      */
-    public function handle()
+    public function handle(LangJsGenerator $generator)
     {
         $target = $this->argument('target');
         $options = [
@@ -69,7 +52,7 @@ class LangJsCommand extends Command
             'no-sort' => $this->option('no-sort'),
         ];
 
-        if ($this->generator->generate($target, $options)) {
+        if ($generator->generate($target, $options)) {
             $this->info("Created: {$target}");
 
             return;


### PR DESCRIPTION
Every time when laravel container initializes, it creates command objects. That's why you shouldn't use Command constructor for dependency injection