### PR TITLE
Added JSON_UNESCAPED_UNICODE flag to json_encode

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -83,7 +83,7 @@ class LangJsGenerator
             $template = str_replace('\'{ langjs }\';', $langjs, $template);
         }
 
-        $template = str_replace('\'{ messages }\'', json_encode($messages), $template);
+        $template = str_replace('\'{ messages }\'', json_encode($messages, JSON_UNESCAPED_UNICODE), $template);
 
         if ($options['compress']) {
             $template = Minifier::minify($template);


### PR DESCRIPTION
It helps to dramatically reduce the generated JavaScript file size

In my testing, I was able to reduce file size from 170kb to 90kb because I had lots of escaped Cyrillic characters.