### PR TITLE
Fix path error Laravel 9+

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -70,11 +70,20 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
 
             $files = $app['files'];
 
-            if ($laravelMajorVersion === 4) {
-                $langs = $app['path.base'].'/app/lang';
-            } elseif ($laravelMajorVersion >= 5) {
-                $langs = $app['path.base'].'/resources/lang';
-            }
+            switch ($laravelMajorVersion) {
+                case 4:
+                    $langs = app('path.base').'/app/lang';
+                    break;
+                case 5:
+                case 6:
+                case 7:
+                case 8:
+                    $langs = app('path.base').'/resources/lang';
+                    break;
+                default:
+                    $langs = app('path.base').'/lang';
+                    break;
+             }
             $messages = $app['config']->get('localization-js.messages');
             $generator = new Generators\LangJsGenerator($files, $langs, $messages);
 


### PR DESCRIPTION
Since Laravel 9, the localization folder is located in the root folder of the project. This commit fixes the error when the 'lang' folder is not found.