### PR TITLE
Fix deprecation warning on PHP 8.2 - String interpolation

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
+++ b/src/Mariuzzo/LaravelJsLocalization/Generators/LangJsGenerator.php
@@ -122,7 +122,7 @@ class LangJsGenerator
         $path = $this->sourcePath;
 
         if (!$this->file->exists($path)) {
-            throw new \Exception("${path} doesn't exists!");
+            throw new \Exception("{$path} doesn't exists!");
         }
 
         foreach ($this->file->allFiles($path) as $file) {


### PR DESCRIPTION
This PR fixes a tiny deprecated functionality that is causing warnings in PHP 8.2 at the moment.

The only thing needed at this point is to replace the `${path}` with `{$path}` (or `$path` without the curly braces) but since you use the `{$var}` syntax in other places I replaced it with `{$path}`  

https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dollar-brace-interpolation