### PR TITLE
Fix lang folder localization for Laravel 10

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -74,6 +74,8 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
                 $langs = $app['path.base'].'/app/lang';
             } elseif ($laravelMajorVersion >= 5) {
                 $langs = $app['path.base'].'/resources/lang';
+            } elseif ($laravelMajorVersion >= 10) {
+                $langs = $app['path.base'].'/lang';
             }
             $messages = $app['config']->get('localization-js.messages');
             $generator = new Generators\LangJsGenerator($files, $langs, $messages);


### PR DESCRIPTION
For Laravel 10 the location of lang files was changed to root folder **lang**. Updated path if it is for laravel version >= 10.