### PR TITLE
Fix on lang folder location error for Laravel version >= 9

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -74,6 +74,8 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
                 $langs = $app['path.base'].'/app/lang';
             } elseif ($laravelMajorVersion >= 5) {
                 $langs = $app['path.base'].'/resources/lang';
+            } elseif ($laravelMajorVersion >= 9) {
+                $langs = $app['path.base'].'/lang';
             }
             $messages = $app['config']->get('localization-js.messages');
             $generator = new Generators\LangJsGenerator($files, $langs, $messages);


### PR DESCRIPTION
For laravel version >= 9 the lang folder changed to project root. This fix ends the error when trying to generate lang files.