### PR TITLE
LaravelJsLocalizationServiceProvider.php : Fix logical error

### DIFF
--- a/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
+++ b/src/Mariuzzo/LaravelJsLocalization/LaravelJsLocalizationServiceProvider.php
@@ -70,12 +70,12 @@ class LaravelJsLocalizationServiceProvider extends ServiceProvider
 
             $files = $app['files'];
 
-            if ($laravelMajorVersion === 4) {
-                $langs = $app['path.base'].'/app/lang';
+            if ($laravelMajorVersion >= 9) {
+                $langs = $app['path.base'].'/lang';
             } elseif ($laravelMajorVersion >= 5) {
                 $langs = $app['path.base'].'/resources/lang';
-            } elseif ($laravelMajorVersion >= 9) {
-                $langs = $app['path.base'].'/lang';
+            } elseif ($laravelMajorVersion === 4) {
+                $langs = $app['path.base'].'/app/lang';
             }
             $messages = $app['config']->get('localization-js.messages');
             $generator = new Generators\LangJsGenerator($files, $langs, $messages);


### PR DESCRIPTION
When the Laravel version is 9 or higher. The second condition will be true and the third does not run at all. The order of the conditions had to be changed.